### PR TITLE
Change `:model-name_id` to `:model_name_id` in defining routes doc

### DIFF
--- a/guides/release/routing/defining-your-routes.md
+++ b/guides/release/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v2.10.0/routing/defining-your-routes.md
+++ b/guides/v2.10.0/routing/defining-your-routes.md
@@ -223,7 +223,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.11.0/routing/defining-your-routes.md
+++ b/guides/v2.11.0/routing/defining-your-routes.md
@@ -222,7 +222,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.12.0/routing/defining-your-routes.md
+++ b/guides/v2.12.0/routing/defining-your-routes.md
@@ -222,7 +222,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.13.0/routing/defining-your-routes.md
+++ b/guides/v2.13.0/routing/defining-your-routes.md
@@ -222,7 +222,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.14.0/routing/defining-your-routes.md
+++ b/guides/v2.14.0/routing/defining-your-routes.md
@@ -222,7 +222,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.15.0/routing/defining-your-routes.md
+++ b/guides/v2.15.0/routing/defining-your-routes.md
@@ -222,7 +222,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.16.0/routing/defining-your-routes.md
+++ b/guides/v2.16.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v2.17.0/routing/defining-your-routes.md
+++ b/guides/v2.17.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v2.18.0/routing/defining-your-routes.md
+++ b/guides/v2.18.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v2.3.0/routing/defining-your-routes.md
+++ b/guides/v2.3.0/routing/defining-your-routes.md
@@ -207,7 +207,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.4.0/routing/defining-your-routes.md
+++ b/guides/v2.4.0/routing/defining-your-routes.md
@@ -207,7 +207,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.5.0/routing/defining-your-routes.md
+++ b/guides/v2.5.0/routing/defining-your-routes.md
@@ -207,7 +207,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.6.0/routing/defining-your-routes.md
+++ b/guides/v2.6.0/routing/defining-your-routes.md
@@ -223,7 +223,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.7.0/routing/defining-your-routes.md
+++ b/guides/v2.7.0/routing/defining-your-routes.md
@@ -223,7 +223,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.8.0/routing/defining-your-routes.md
+++ b/guides/v2.8.0/routing/defining-your-routes.md
@@ -223,7 +223,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v2.9.0/routing/defining-your-routes.md
+++ b/guides/v2.9.0/routing/defining-your-routes.md
@@ -223,7 +223,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will *not* work properly:

--- a/guides/v3.0.0/routing/defining-your-routes.md
+++ b/guides/v3.0.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.1.0/routing/defining-your-routes.md
+++ b/guides/v3.1.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.10.0/routing/defining-your-routes.md
+++ b/guides/v3.10.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.11.0/routing/defining-your-routes.md
+++ b/guides/v3.11.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.12.0/routing/defining-your-routes.md
+++ b/guides/v3.12.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.2.0/routing/defining-your-routes.md
+++ b/guides/v3.2.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.3.0/routing/defining-your-routes.md
+++ b/guides/v3.3.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.4.0/routing/defining-your-routes.md
+++ b/guides/v3.4.0/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.5.0/routing/defining-your-routes.md
+++ b/guides/v3.5.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.6.0/routing/defining-your-routes.md
+++ b/guides/v3.6.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.7.0/routing/defining-your-routes.md
+++ b/guides/v3.7.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.8.0/routing/defining-your-routes.md
+++ b/guides/v3.8.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:

--- a/guides/v3.9.0/routing/defining-your-routes.md
+++ b/guides/v3.9.0/routing/defining-your-routes.md
@@ -278,7 +278,7 @@ Router.map(function() {
 
 If the user navigates to `/post/5`, the route will then have the `post_id` of
 `5` to use to load the correct post.
-Ember follows the convention of `:model-name_id` for two reasons.
+Ember follows the convention of `:model_name_id` for two reasons.
 The first reason is that Routes know how to fetch the right model by default, if you follow the convention.
 The second is that `params` is an object, and can only have one value associated with a key.
 To put it in code, the following will _not_ work properly:


### PR DESCRIPTION
`:model-name_id` incorrectly implies that a multiword model would be dasherized with `_id` appended at the end.

This doesn't work with the [routes-segments-snake-case lint rule](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/routes-segments-snake-case.md) which will complain about the dash in the dynamic segment, and it also means that you'd need to use `params['blog-post_id']` instead of `params.blog_post_id` which I don't think was intended by the original author here.